### PR TITLE
fix(dashboard): Ensure notice modal height is updated on mobile auto-popup

### DIFF
--- a/src/views/dashboard/Dashboard.vue
+++ b/src/views/dashboard/Dashboard.vue
@@ -1406,6 +1406,9 @@ export default {
           currentNoticeIndex.value = popupNoticeIndex;
           showNoticeDetails.value = true;
           sessionStorage.setItem(popupShownKey, 'true');
+          nextTick(() => {
+            updateModalHeight();
+          });
         }
       }
     };


### PR DESCRIPTION
Before:
![Before](https://github.com/user-attachments/assets/e1051cc9-210a-4982-b585-8d2e73ab199d)
After:
![After](https://github.com/user-attachments/assets/8f8b7126-46de-4f20-b6f7-b2e73dd04614)
